### PR TITLE
Added convenience function to add multiple links at once

### DIFF
--- a/library/Hal/Resource.php
+++ b/library/Hal/Resource.php
@@ -98,6 +98,23 @@ class Resource extends AbstractHal
 
         return $this;
     }
+
+    /**
+     * Convenience function to set multiple links at once
+     * 
+     * @see Resource::setLink()
+     * @param array   $links    Array of Link objects
+     * @param boolean $singular
+     */
+    public function setLinks(array $links, $singular = false)
+    {
+        foreach ($links as $link) {
+            $this->setLink($link, $singular);
+        }
+
+        return $this;
+    }
+
     /**
      *
      * @param array $data

--- a/tests/library/Hal/ResourceTest.php
+++ b/tests/library/Hal/ResourceTest.php
@@ -102,4 +102,62 @@ EOF;
         $expected = json_decode($JSON);
         $this->assertEquals($expected, $actual);
     }
+
+    public function testSetLinksMultiple()
+    {
+        $parent = new Resource('/dogs');
+        $links = array(
+          new Link('/dogs?q={text}', 'search'),
+          new Link('/dogs?q={text}&limit={limit}', 'search')
+        );
+        $parent->setLinks($links);
+
+        $actual = json_decode($parent);
+
+        $JSON = <<<EOF
+{
+   "_links":{
+      "self":{
+         "href":"\/dogs"
+      },
+      "search":[{
+         "href":"\/dogs?q={text}"
+      },{
+         "href":"\/dogs?q={text}&limit={limit}"
+      }]
+   }
+}
+EOF;
+
+        $expected = json_decode($JSON);
+        $this->assertEquals($expected, $actual);
+    }
+
+     public function testSetLinksMultipleSingluar()
+    {
+        $parent = new Resource('/dogs');
+        $links = array(
+          new Link('/dogs?q={text}', 'search'),
+          new Link('/dogs?q={text}&limit={limit}', 'search')
+        );
+        $parent->setLinks($links, true);
+
+        $actual = json_decode($parent);
+
+        $JSON = <<<EOF
+{
+   "_links":{
+      "self":{
+         "href":"\/dogs"
+      },
+      "search":{
+         "href":"\/dogs?q={text}&limit={limit}"
+      }
+   }
+}
+EOF;
+
+        $expected = json_decode($JSON);
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
I ran into a situation where my entities were returning arrays of Links. It seems prettier when then from the outside you can just call setLinks() on the Resource and pass the array in. 

Unit tests included.
