### PR TITLE
Allow empty self link

### DIFF
--- a/library/Hal/Link.php
+++ b/library/Hal/Link.php
@@ -205,7 +205,12 @@ class Link extends AbstractHal
      */
     public function toArray()
     {
-        $link = array('href' => $this->getHref());
+        $href = $this->getHref();
+        if (empty($href)) {
+            return array();
+        }
+
+        $link = array('href' => $href);
         if($this->getTitle()){
             $link['title'] = $this->getTitle();
         }

--- a/library/Hal/Resource.php
+++ b/library/Hal/Resource.php
@@ -104,7 +104,7 @@ class Resource extends AbstractHal
 
     /**
      * Convenience function to set multiple links at once
-     * 
+     *
      * @see Resource::setLink()
      * @param array   $links    Array of Link objects
      * @param boolean $singular
@@ -155,7 +155,11 @@ class Resource extends AbstractHal
     {
         $data = array();
         foreach ($this->_links as $rel => $link) {
-            $data['_links'][$rel] = $this->_recurseLinks($link);
+            $links = $this->_recurseLinks($link);
+
+            if (!empty($links)) {
+                $data['_links'][$rel] = $links;
+            }
         }
         foreach ($this->_data as $key => $value) {
             $data[$key] = $value;
@@ -172,7 +176,7 @@ class Resource extends AbstractHal
     protected function _recurseEmbedded($embeded)
     {
         $result = array();
-        if($embeded instanceof  self){
+        if($embeded instanceof self){
             $result = $embeded->toArray();
         } else {
             foreach ($embeded as $embed) {

--- a/tests/library/Hal/ResourceTest.php
+++ b/tests/library/Hal/ResourceTest.php
@@ -323,11 +323,53 @@ EOF;
 
         $parent = new Resource('/dogs');
         $parent->setLink(new Link('/dogs?q={text}', 'search'));
-        
+
         $parent->setEmbedded('dog', null);
-        
+
         $this->assertEquals(
             json_decode($fixture), json_decode((string)$parent)
+        );
+    }
+
+    /**
+     * This tests adding a resource with no self link
+     */
+    public function testEmptySelfLink()
+    {
+        $fixture = <<<'EOF'
+{
+    "data": "value"
+}
+EOF;
+
+        $parent = new Resource('', array('data' => 'value'));
+
+        $this->assertEquals(
+            json_decode($fixture), json_decode((string) $parent)
+        );
+    }
+
+    /**
+     * This tests adding a resource with no self link
+     */
+    public function testEmptySelfLinkWithOthers()
+    {
+        $fixture = <<<'EOF'
+{
+    "_links":{
+        "search":{
+            "href":"/dogs?q={text}"
+        }
+    },
+    "data": "value"
+}
+EOF;
+
+        $parent = new Resource('', array('data' => 'value'));
+        $parent->setLink(new Link('/dogs?q={text}', 'search'));
+
+        $this->assertEquals(
+            json_decode($fixture), json_decode((string) $parent)
         );
     }
 }


### PR DESCRIPTION
HAL specs now allow to have resources with no self link (where applicable).
