### PR TITLE
Fix resource issues

### DIFF
--- a/library/Hal/Resource.php
+++ b/library/Hal/Resource.php
@@ -287,33 +287,29 @@ class Resource extends AbstractHal
      *
      * @param SimpleXMLElement $xml
      * @param array $data
-     * @param string $key
+     * @param string $keyOverride
      */
-    protected function _addData(SimpleXMLElement $xml, $data, $key = null)
+    protected function _addData(SimpleXMLElement $xml, array $data, $keyOverride = null)
     {
-        if(null !== $key && !is_numeric($key)){
-            $node = $xml->addChild($key);
-            $this->_addData($node, $data);
-        } else {
-            foreach ($data as $_key => $value) {
-                if(!is_numeric($_key) && is_array($value)){
-                    foreach ($value as $v) {
-                        $c = $xml->addChild($_key)->addChild($_key);
-                        foreach ($v as $name => $value) {
-                            $c->addChild($name, $value);
-                        }
-                    }
-                }
-                elseif(!is_numeric($_key) && !is_array($value) && $value){
-                    if($key && !is_numeric($key)){
-                        $_k = $key;
-                    } else {
-                        $_k = $_key;
-                    }
-                        $xml->addChild($_k, $value);
-                } elseif(is_array($value)){
-                    $this->_addData($xml, $value, $_key);
-                }
+        foreach ($data as $key => $value) {
+
+            // alpha-numeric key => array value
+            if(!is_numeric($key) && is_array($value)){
+                $c = $xml->addChild($key);
+                $this->_addData($c, $value, $key);
+            }
+
+            // alpha-numeric key => non-array value
+            elseif(!is_numeric($key) && !is_array($value)){
+                $xml->addChild($key, $value);
+
+            // numeric key => array value
+            } elseif(is_array($value)){
+                $this->_addData($xml, $value);
+
+            // numeric key => non-array value
+            } else {
+                $xml->addChild($keyOverride, $value);
             }
         }
     }


### PR DESCRIPTION
Sets of data that demonstrate the issue that was solved per commit:

2b6875b91433640b660734ae026df30b755aabff: Allow null to be the value of an embedded item.

``` php
$noNullValues = array(
    "_links" => array(
        "self" => array("href" => "articles/123")
    ),
    "_embedded" => array(
        "topics" => array(
            array(
                "_links" => array(
                    "self" => array("href" => "topics/sciencs")
                ),
                "name" => "science",
                "slug" => "science"
            ),
            array(
                "_links" => array(
                    "self" => array("href" => "topics/astronomy")
                ),
                "name" => "astronomy",
                "slug" => "astronomy"
            )
        ),
        "tags" => null
    )
);
```

2590f00f50a7ae1c07c0bb7f2b7dd87b9900e84: Allow a link element to be an array of links. See 'admin' link element in the spec: http://stateless.co/hal_specification.html#examples

``` php
$multipleLinks = array(
    "_links" => array(
        "self" => array("href" => "articles/123"),
        "related_articles" => array(
            array("href" => "articles/124"),
            array("href" => "articles/125")
        )
    )
);
```

d4a7834db2257ce54a47ffe50cdb1b920e4890c9: Reworked _addData() method to correct a couple problems and simplify. When data consists of nested, associative arrays, the keys that were outputted into XML were incorrect. When a top level element contained an array containing string elements, _addData() failed because it was expected the values of the array to be arrays themselves.

``` php
$addData = array(
    "_links" => array(
        "self" => array("href" => "articles/123"),
        "related_articles" => array(
            array("href" => "articles/124"),
            array("href" => "articles/125")
        )
    ),
    "keywords" => array(
        "testOne" => array("space", "astronomy", "orbit"),
        "testTwo" => array("earth", "meteor", "star")
    ),
    "nested" => array(
        "moreNested" => array(
            "evenMoreNested" => array("mario", "luigi", "peach")
        ),
        "anotherNested" => array("metal man", "wood man", "air man")
    ),
    "string" => array("one", "two", "three")
);
```
