### PR TITLE
Removed version property from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name":"zircote/hal",
     "type":"library",
-    "version":"0.3.2",
     "time":"2012-11-27",
     "license":"Apache-2.0",
     "description":"A PHP implementation of HAL http://stateless.co/hal_specification.html",


### PR DESCRIPTION
This will enable versions for composer/packagist to be managed soley by
tags and no longer require the version property to be updated manaually.
This subsequently resolves future issues with tagged releases from not
showing up due to forgoted version updates to the `composer.json`
