### PR TITLE
Allow Hal\Resource::__construct to accept an instance of \Hal\Link in first argument

### DIFF
--- a/library/Hal/Resource.php
+++ b/library/Hal/Resource.php
@@ -61,7 +61,7 @@ class Resource extends AbstractHal
     protected $jsonNumericCheck = self::JSON_NUMERIC_CHECK_OFF;
     /**
      *
-     * @param string $href
+	 * @param string|\Hal\Link $href
      * @param array $data
      * @param string|null $title
      * @param string|null $name

--- a/tests/library/Hal/ResourceTest.php
+++ b/tests/library/Hal/ResourceTest.php
@@ -29,7 +29,31 @@ use Hal\Link;
  */
 class ResourceTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSetSingleLink()
+	public function testConstructWithLinkObject()
+	{
+		$self = new Link('/dogs', 'self');
+
+		$parent = new Resource($self);
+		
+		$actual = json_decode($parent);
+
+
+        $JSON = <<<EOF
+{
+   "_links":{
+      "self":{
+         "href":"\/dogs"
+      }
+   }
+}
+EOF;
+
+		$expected = json_decode($JSON);
+
+		$this->assertEquals($expected, $actual);	
+	}
+
+	public function testSetSingleLink()
     {
         $parent = new Resource('/dogs');
         $parent->setLink(new Link('/dogs?q={text}', 'search'));


### PR DESCRIPTION
This will allow users of the library to extend the Link class and manually inject the new class instance for the Resource's 'self' link.
