### PR TITLE
Resource class is not unit testable

### DIFF
--- a/library/Hal/Resource.php
+++ b/library/Hal/Resource.php
@@ -59,6 +59,7 @@ class Resource extends AbstractHal
      * @var bool
      */
     protected $jsonNumericCheck = self::JSON_NUMERIC_CHECK_OFF;
+
     /**
      *
      * @param string $href
@@ -70,9 +71,17 @@ class Resource extends AbstractHal
     public function __construct($href, array $data = array(), $title = null, $name = null, $hreflang = null)
     {
         $this->setLink(
-            new Link($href, 'self', $title, $name, $hreflang)
+            $this->createLink($href, 'self', $title, $name, $hreflang)
         );
         $this->setData($data);
+    }
+
+    /**
+     * @return Link
+     */
+    protected function createLink($href, $rel, $title, $name, $hreflang)
+    {
+        return new Link($href, $rel, $title, $name, $hreflang);
     }
 
     /**


### PR DESCRIPTION
Hal\Resource should not directly call `new Link` in the constructor.
Refactor class to use a factory method so the `Link` class can be
mocked.

Fixes #13
