### PR TITLE
Specify namespace character in autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload":{
         "psr-0":{
-            "Hal":"library"
+            "Hal\\":"library"
         }
     }
 }


### PR DESCRIPTION
Without an namespace character, this is causing collisions with our
legacy application which uses _Halo_ as a PEAR style namespace prefix.